### PR TITLE
Hiding shorts on m.youtube.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
       {
         "matches": ["*://*.youtube.com/*"],
         "js": ["./src/main.js"],
-        "all_frames": true
+        "run_at": "document_idle"
       }
     ],
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,66 @@ let observer = null;
 let hideYTShortsVideos = true;
 let hideYTShortsTab = false;
 
-const SHORTS_CONTAINERS_TAG = "ytd-grid-video-renderer, ytd-video-renderer, ytd-compact-video-renderer"
-const SHELF_TAG = "ytd-reel-shelf-renderer"
+/* ON DESKTROP */
+const DESKTOP_SHORTS_CONTAINERS_TAG = [
+  // videos on Home page
+  ["ytd-rich-item-renderer"],
+  // videos on Subscription page
+  ["ytd-grid-video-renderer"], 
+  // videos on Search page
+  ["ytd-video-renderer"], 
+  // videos on Video page
+  ["ytd-compact-video-renderer"],
+].join(",")
+const DESKTOP_SHELF_TAG = "ytd-reel-shelf-renderer"
+
+/* ON MOBILE */
+let isMobile = location.hostname == "m.youtube.com";
+const MOBILE_SHORTS_CONTAINERS_TAG = [
+  // videos on Home page
+  ["ytm-rich-item-renderer"], 
+  // videos on Subscription page
+  ["div[tab-identifier='FEsubscriptions']>ytm-section-list-renderer>lazy-list>ytm-item-section-renderer"], 
+  // videos on Search page and Video page
+  ["ytm-video-with-context-renderer"],
+].join(",")
+const MOBILE_SHELF_TAG = "ytm-reel-shelf-renderer"
+const MOBILE_SHORTS_TAB_SELECTOR = "ytm-pivot-bar-item-renderer>div[class='pivot-bar-item-tab pivot-shorts']"
+
+/* on desktop and mobile */
+const SHELF_TAG_REGEX = /yt[dm]-reel-shelf-renderer/gm
+const SHELF_ITEM_TAG_REGEX = /yt[dm]-reel-item-renderer/gm
+
+
+function waitForElement(selector) {
+  return new Promise(resolve => {
+    let element = document.querySelector(selector);
+    if (element) {
+      return resolve(document.querySelector(selector));
+    }
+    const observer = new MutationObserver(() => {
+      element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+  });
+}
+
+function hideElement(hide, element) {
+  if (hide) {
+    if (element !== null) {
+      element.setAttribute("hidden", true);
+    }
+  }
+  else {
+    if (element.hasAttribute("hidden")) {
+      element.removeAttribute("hidden");
+    }
+  }
+}
 
 
 function setup() {
@@ -21,19 +79,23 @@ function setup() {
     else {
       hideYTShortsTab = value.hideYTShortsTab;
     }
-
+    
     hideShortsTab(value.hideYTShortsTab);
     addObserver();
   });
 }
 
 function hideShorts(hide = true) {
-  let elements = document.querySelectorAll(SHORTS_CONTAINERS_TAG + ", " + SHELF_TAG);
+  let selectorString = isMobile ? 
+    MOBILE_SHORTS_CONTAINERS_TAG + "," + MOBILE_SHELF_TAG 
+    : DESKTOP_SHORTS_CONTAINERS_TAG + "," + DESKTOP_SHELF_TAG;
+  elements = document.querySelectorAll(selectorString);
   elements.forEach(element => {
     // hide whole shelf if just contains "ytd-reel-item-renderer" tag. For now seems to be only used for yt-shorts videos
     // and hide any video container that contains a ref link to shorts
-    if ((element.tagName.toLowerCase() === SHELF_TAG.toLowerCase() && element.innerHTML.search("ytd-reel-item-renderer") != -1) 
-    || element.innerHTML.search("href=\"/shorts/") != -1) 
+    if ((element.tagName.toLowerCase().match(SHELF_TAG_REGEX) 
+      && element.innerHTML.search(SHELF_ITEM_TAG_REGEX) != -1) 
+      || element.innerHTML.search("href=\"/shorts/") != -1)
     {
       if (hide) {
         element.setAttribute("hidden", true);
@@ -46,24 +108,18 @@ function hideShorts(hide = true) {
 }
 
 function hideShortsTab(hide) {
-  let tabElement = document.querySelector('ytd-guide-entry-renderer>a:not([href])');
-  let miniTabElement = document.querySelector("ytd-mini-guide-entry-renderer>a:not([href])");
-
-  if (hide) {
-    if (tabElement !== null) {
-      tabElement.setAttribute("hidden", true);
-    }
-    if (miniTabElement !== null) {
-      miniTabElement.setAttribute("hidden", true);
-    }
+  if (isMobile) {
+    waitForElement(MOBILE_SHORTS_TAB_SELECTOR).then((element) => {
+      hideElement(hide, element.parentElement)
+    });
   }
   else {
-    if (tabElement.hasAttribute("hidden")) {
-      tabElement.removeAttribute("hidden");
-    }
-    if (miniTabElement.hasAttribute("hidden")) {
-      miniTabElement.removeAttribute("hidden");
-    }
+    waitForElement("ytd-guide-entry-renderer>a:not([href])").then((element) => {
+      hideElement(hide, element)
+    });
+    waitForElement("ytd-mini-guide-entry-renderer>a:not([href])").then((element) => {
+      hideElement(hide, element)
+    });
   }
 }
 
@@ -71,7 +127,7 @@ function hideShortsTab(hide) {
 function addObserver() {
   if (observer === null && hideYTShortsVideos) {
     observer = new MutationObserver(hideShorts);
-    observer.observe(document.getElementById("content"), {childList:true, subtree:true});
+    observer.observe(document.getElementById(isMobile ? "app" : "content"), {childList:true, subtree:true});
     hideShorts(true);
   }
   else if (observer !== null && !hideYTShortsVideos) {
@@ -85,6 +141,4 @@ chrome.storage.onChanged.addListener(function() {
   setup();
 });
 
-window.addEventListener('yt-rendererstamper-finished', (event) => { 
-  setup();
-});
+setup();


### PR DESCRIPTION
New:
- hiding shorts tab and shorts videos in mobile version of youtube (m.youtube.com)
Changes in code:
- Using MutationObserver instead of eventListener with event 'yt-rendererstamper-finished' for both hiding shorts tab and shorts videos
