### PR TITLE
Fix/hiding stops working in new tab

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "version": "1.7.3",
+    "version": "1.7.4",
 
     "name": "__MSG_extensionName__",
     "description": "__MSG_extensionDescription__",

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 2,
-    "version": "1.7.3",
+    "version": "1.7.4",
 
     "name": "__MSG_extensionName__",
     "description": "__MSG_extensionDescription__",

--- a/src/main.js
+++ b/src/main.js
@@ -85,16 +85,11 @@ function waitForElement(selector, observeElement = document.body, {childList = t
     if (element) {
       return resolve(element);
     }
-    const isAdvSelector = selector.indexOf('>') > -1;
-    const elementObserver = new MutationObserver((mutationList) => {
-      for (const mutation of mutationList) {
-        element = isAdvSelector ? mutation.target.querySelector(selector) : mutation.target;
-
-        if ((!isAdvSelector && element.matches(selector)) || (isAdvSelector && element)) { 
-          resolve(element);
-          elementObserver.disconnect();
-          break;
-        }
+    const elementObserver = new MutationObserver(() => {
+      element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        elementObserver.disconnect();
       }
     });
     elementObserver.observe(observeElement, { childList: childList, subtree: subtree });
@@ -108,17 +103,12 @@ function waitForElementTimeout(selector, observeElement = document.body, {childL
       return resolve(element);
     }
     let timer = null;
-    const isAdvSelector = selector.indexOf('>') > -1;
-    const elementObserver = new MutationObserver((mutationList) => {
-      for (const mutation of mutationList) {
-        element = isAdvSelector ? mutation.target.querySelector(selector) : mutation.target;
-
-        if ((!isAdvSelector && element.matches(selector)) || (isAdvSelector && element)) { 
-          clearTimeout(timer);
-          resolve(element);
-          elementObserver.disconnect();
-          break;
-        }
+    const elementObserver = new MutationObserver(() => {
+      element = document.querySelector(selector);
+      if (element) {
+        clearTimeout(timer);
+        resolve(element);
+        elementObserver.disconnect();
       }
     });
     elementObserver.observe(observeElement, {childList: childList, subtree: subtree});


### PR DESCRIPTION
Reverting back using document.querySelector(..) inside MutationObserver instead of mutationList parameter.