### PR TITLE
add option to hide yt posts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 [![Extension's Chrome Web Store users](https://img.shields.io/chrome-web-store/users/ankepacjgoajhjpenegknbefpmfffdic?label=Chrome%20Users&logo=google%20chrome)](https://chrome.google.com/webstore/detail/hide-shorts-for-youtube/ankepacjgoajhjpenegknbefpmfffdic)
 [![Licence](https://img.shields.io/github/license/Vulpelo/hide-youtube-shorts)](https://github.com/Vulpelo/hide-youtube-shorts/blob/master/LICENCE.md)
 
-Firefox add-on that hides YouTube-shorts videos from home page, subscriptions and search results. 
+Firefox add-on that hides YouTube-shorts videos from home page, subscriptions and search results.
 Also allows you to hide "Shorts" tab.
 
 ## Features
@@ -20,6 +20,7 @@ Also allows you to hide "Shorts" tab.
 - Hiding live videos (experimental, off by default)
 - Hiding 'Upcoming' videos (experimental, off by default)
 - Redirect shorts to original video player (experimental, off by default)
+- Hiding posts (experimental, off by default)
 
 ## Installation
 
@@ -33,7 +34,7 @@ Prepare files for chrome and firefox versions by running `npm run prepare` comma
 
 You can also run `npm run zip` command to prepare and create zip archives for both chrome and firefox versions. Both will be placed in `./build` directory
 
-### Firefox 
+### Firefox
 
 Add the Add-on temporarily:
 1. In Firefox browser go to the debugging page by typing in url <b>[about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox)</b>
@@ -54,7 +55,7 @@ Add the Add-on manually:
 
 # FAQ
 - Going "Back" in navigation again redirects tab to the original video player
-    - Chrome and Firefox on Android don't support [loadReplace option](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update), meaning that clicking "Back" button will direct to the original video URL (not the page from which video was clicked on). This will then again redirect the page. You can click and hold the back button to display list of previous pages and select desired page from here. 
+    - Chrome and Firefox on Android don't support [loadReplace option](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update), meaning that clicking "Back" button will direct to the original video URL (not the page from which video was clicked on). This will then again redirect the page. You can click and hold the back button to display list of previous pages and select desired page from here.
 - After addon installation shorts are still visible on youtube's page
     - It is also required to refresh the youtube's page in order for the scripts to load.
 - After a while youtube starts slowing down

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,7 +1,7 @@
 {
     "extensionName": {"message": "Hide shorts for Youtube™"},
     "extensionDescription": {"message": "Hides shorts from YouTube™ from home page, subscriptions and search results."},
-    
+
     "cfg_hide_videos": {"message": "Hide Shorts videos"},
     "cfg_hide_tab": {"message": "Hide Shorts tab"},
     "cfg_hide_notifications": {"message": "Hide Shorts notifications"},
@@ -10,7 +10,7 @@
     "setting_experimental_text": {"message": "Experimental"},
     "settings_hiding_on_text": {"message": "Hiding on"},
     "settings_performance_text": {"message": "Performance"},
-    
+
     "cfg_hide_videos_home": {"message": "Home page"},
     "cfg_hide_videos_subscription": {"message": "Subscriptions page"},
     "cfg_hide_videos_search": {"message": "Search page"},
@@ -27,5 +27,6 @@
 
     "cfg_hide_live_videos": {"message": "Hide Live videos"},
     "cfg_hide_upcoming_videos": {"message": "Hide 'Upcoming' videos"},
-    "cfg_shorts_in_original_video_player": {"message": "Redirect to original video player"}
+    "cfg_shorts_in_original_video_player": {"message": "Redirect to original video player"},
+    "cfg_hide_posts": {"message": "Hide posts"}
 }

--- a/src/menu/popup.html
+++ b/src/menu/popup.html
@@ -18,7 +18,7 @@
             <legend id="settings_text">
                 Options
             </legend>
-    
+
             <label class="setting">
                 <input type="checkbox" id="hideYTShortsVideosInput">
                 <span id="hide_videos_text" class="switchLabel" title="">
@@ -145,6 +145,13 @@
                             <input type="checkbox" id="shortsInOriginalVideoPlayerInputCheckbox">
                             <span id="shorts_in_original_video_player_text" class="switchLabel">
                                 Redirect original video player
+                            </span>
+                        </label>
+                        <br>
+                        <label class="setting">
+                            <input type="checkbox" id="hidingPostsCheckbox">
+                            <span id="hide_posts_text" class="switchLabel">
+	                            Hide posts
                             </span>
                         </label>
                     </fieldset>

--- a/src/menu/popup.js
+++ b/src/menu/popup.js
@@ -54,7 +54,7 @@ window.onload = function () {
             chrome.storage.local.set({ hideYTShortsVideosOnChannelPage: e.target.checked });
         })
 
-        // close button for shelf on subscription page 
+        // close button for shelf on subscription page
         const subscriptionShelfCloseButtonInputCheckbox = document.getElementById("subscriptionShelfCloseButtonInputCheckbox");
         if (value.subscriptionShelfCloseButton != undefined)
             subscriptionShelfCloseButtonInputCheckbox.checked = value.subscriptionShelfCloseButton;
@@ -126,6 +126,15 @@ window.onload = function () {
         hidingUpcomingVideosInputCheckbox.addEventListener("input", function (e) {
             chrome.storage.local.set({ hidingUpcomingVideosActive: e.target.checked });
         })
+
+        // hiding posts
+        const hidingPostsCheckbox = document.getElementById("hidingPostsCheckbox");
+        if (value.hidingPostsActive != undefined)
+            hidingPostsCheckbox.checked = value.hidingPostsActive;
+        hidingPostsCheckbox.addEventListener("input", function (e) {
+            chrome.storage.local.set({ hidingPostsActive: e.target.checked });
+        })
+
     });
 
     // Set language
@@ -153,6 +162,7 @@ window.onload = function () {
     document.getElementById("hide_live_videos_text").textContent = chrome.i18n.getMessage("cfg_hide_live_videos");
     document.getElementById("hide_upcoming_videos_text").textContent = chrome.i18n.getMessage("cfg_hide_upcoming_videos");
     document.getElementById("shorts_in_original_video_player_text").textContent = chrome.i18n.getMessage("cfg_shorts_in_original_video_player");
+    document.getElementById("hide_posts_text").textContent = chrome.i18n.getMessage("cfg_hide_posts");
 
     // version
     let manifestData = chrome.runtime.getManifest();


### PR DESCRIPTION
Implements #72

I really got bothered by those random irrelevant posts staying on my recommendations feed for weeks, fortunately it was relatively easy to modify this extension to also hide shorts :). It seems to work fine on my desktop and my phone (both Firefox). I've included it as an experimental option though, disabled by default.

The only thing that's missing is the translations for non-English. And sorry about the whitespace changes