### PR TITLE
Add dark mode

### DIFF
--- a/src/menu/color-scheme.js
+++ b/src/menu/color-scheme.js
@@ -1,0 +1,34 @@
+const root = document.documentElement;
+const toggleBtn = document.getElementById("theme-toggle");
+
+const savedTheme = localStorage.getItem("theme");
+if (savedTheme) {
+  root.setAttribute("data-theme", savedTheme);
+}
+
+/**
+ * Returns the next theme to set based on the current theme.
+ * @param {string | null} current - The current theme.
+ * @returns {"dark" | "light"} The next theme to set.
+ */
+function getNextTheme(current) {
+  if (current === "dark") {
+    return "light";
+  } else if (current === "light") {
+    return "dark";
+  } else {
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    return prefersDark ? "light" : "dark";
+  }
+}
+
+function toggleTheme() {
+  const current = root.getAttribute("data-theme");
+  const next = getNextTheme(current);
+  root.setAttribute("data-theme", next);
+  localStorage.setItem("theme", next);
+}
+
+toggleBtn.addEventListener("click", toggleTheme);

--- a/src/menu/popup-color-scheme.css
+++ b/src/menu/popup-color-scheme.css
@@ -1,0 +1,41 @@
+#theme-toggle {
+  display: flex;
+  justify-content: end;
+}
+
+#theme-button {
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  font-size: 1.2rem;
+  display: grid;
+}
+
+#theme-button span {
+  grid-area: 1 / 1;
+}
+
+#theme-button .sun {
+  opacity: 1;
+}
+
+#theme-button .moon {
+  opacity: 0;
+}
+
+[data-theme="dark"] #theme-button .sun {
+  opacity: 0;
+}
+
+[data-theme="dark"] #theme-button .moon {
+  opacity: 1;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) #theme-button .sun {
+    opacity: 0;
+  }
+  :root:not([data-theme]) #theme-button .moon {
+    opacity: 1;
+  }
+}

--- a/src/menu/popup.css
+++ b/src/menu/popup.css
@@ -1,7 +1,24 @@
+:root {
+  --color-bg: #fefefe;
+  --color-text: #111111;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #111111;
+    --color-text: #fefefe;
+  }
+
+  #ghlink {
+    filter: invert(100%);
+  }
+}
+
 body {
   max-width: 14rem;
   min-width: 12rem;
   height: 100%;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .bottom {
@@ -37,8 +54,6 @@ body {
   width: 120px;
   left: 0;
   visibility: hidden;
-  background-color: black;
-  color: #fff;
   text-align: center;
   border-radius: 6px;
   padding: 5px 5px;
@@ -62,7 +77,6 @@ body {
 
 details {
   width: 100%;
-  background: #ffffff;
   border-radius: 8px;
   position: relative;
 }
@@ -87,5 +101,4 @@ summary:hover,
   pointer-events: none;
   position: absolute;
   top: 0.75em;
-  background: #ffffff;
 }

--- a/src/menu/popup.css
+++ b/src/menu/popup.css
@@ -1,90 +1,91 @@
 body {
-	max-width: 14rem;
-	min-width: 12rem;
-    height: 100%;
+  max-width: 14rem;
+  min-width: 12rem;
+  height: 100%;
 }
 
 .bottom {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    margin-top: 5px;
-    height: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 5px;
+  height: 20px;
 }
 .right {
-    text-align: right;
+  text-align: right;
 }
 
 .setting {
-    user-select: none;
+  user-select: none;
 }
 
 #hideYTShortsVideosInput:checked + span + .rearrangeVideosContent {
-    display: inline;
-    width: 100%;
-    opacity: 1;
-    pointer-events: auto;
-    cursor: auto;
-    visibility: visible;
+  display: inline;
+  width: 100%;
+  opacity: 1;
+  pointer-events: auto;
+  cursor: auto;
+  visibility: visible;
 }
 
 .more-dropdown {
-    max-height: 210px; 
-    overflow-y: scroll;
-    overflow-x: hidden;
+  max-height: 210px;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .tooltip .tooltiptext {
-    width: 120px;
-    left: 0; 
-    visibility: hidden;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 5px;
+  width: 120px;
+  left: 0;
+  visibility: hidden;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 5px;
 }
 
 .tooltip {
-    border-bottom: 1px dotted black;
+  border-bottom: 1px dotted black;
 }
 
 .tooltiptext {
-    display: block;
-    position: absolute;
-    z-index: 9999;
-    bottom: 100%;
+  display: block;
+  position: absolute;
+  z-index: 9999;
+  bottom: 100%;
 }
 
 .tooltip:hover > .tooltiptext {
-    transition-delay: 700ms;
-    visibility: visible;
+  transition-delay: 700ms;
+  visibility: visible;
 }
 
 details {
-	width: 100%;
-	background: #ffffff;
-	border-radius: 8px;
-	position: relative;
+  width: 100%;
+  background: #ffffff;
+  border-radius: 8px;
+  position: relative;
 }
 
 .summary-title.details {
-	user-select: none;
+  user-select: none;
 }
 
-summary:hover, .details {
-	cursor: pointer;
+summary:hover,
+.details {
+  cursor: pointer;
 }
 
 .summary-content.details {
-	border-top: 1px solid #e2e8f0;
-	cursor: default;
-	line-height: 1.5;
+  border-top: 1px solid #e2e8f0;
+  cursor: default;
+  line-height: 1.5;
 }
 
 .summary-chevron-up,
 .summary-chevron-down {
-	pointer-events: none;
-	position: absolute;
-	top: 0.75em;
-	background: #ffffff;
+  pointer-events: none;
+  position: absolute;
+  top: 0.75em;
+  background: #ffffff;
 }

--- a/src/menu/popup.css
+++ b/src/menu/popup.css
@@ -2,15 +2,34 @@
   --color-bg: #fefefe;
   --color-text: #111111;
 }
+
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: #111111;
     --color-text: #fefefe;
   }
 
-  #ghlink {
+  #ghlink:not([data-theme]) {
     filter: invert(100%);
   }
+}
+
+:root[data-theme="light"] {
+  --color-bg: #fefefe;
+  --color-text: #111111;
+}
+
+:root[data-theme="dark"] {
+  --color-bg: #111111;
+  --color-text: #fefefe;
+}
+
+:root[data-theme="light"] #ghlink {
+  filter: none;
+}
+
+:root[data-theme="dark"] #ghlink {
+  filter: invert(100%);
 }
 
 body {

--- a/src/menu/popup.css
+++ b/src/menu/popup.css
@@ -1,16 +1,16 @@
 :root {
-  --color-bg: #fefefe;
+  --color-bg: #eeeeee;
   --color-text: #111111;
-  --color-tooltip-bg: #fefefe;
+  --color-tooltip-bg: #eeeeee;
   --color-tooltip-text: #111111;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: #111111;
-    --color-text: #fefefe;
+    --color-text: #eeeeee;
     --color-tooltip-bg: #111111;
-    --color-tooltip-text: #fefefe;
+    --color-tooltip-text: #eeeeee;
   }
 
   #ghlink:not([data-theme]) {
@@ -19,17 +19,17 @@
 }
 
 :root[data-theme="light"] {
-  --color-bg: #fefefe;
+  --color-bg: #eeeeee;
   --color-text: #111111;
-  --color-tooltip-bg: #fefefe;
+  --color-tooltip-bg: #eeeeee;
   --color-tooltip-text: #111111;
 }
 
 :root[data-theme="dark"] {
   --color-bg: #111111;
-  --color-text: #fefefe;
+  --color-text: #eeeeee;
   --color-tooltip-bg: #111111;
-  --color-tooltip-text: #fefefe;
+  --color-tooltip-text: #eeeeee;
 }
 
 :root[data-theme="light"] #ghlink {

--- a/src/menu/popup.css
+++ b/src/menu/popup.css
@@ -1,12 +1,16 @@
 :root {
   --color-bg: #fefefe;
   --color-text: #111111;
+  --color-tooltip-bg: #fefefe;
+  --color-tooltip-text: #111111;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: #111111;
     --color-text: #fefefe;
+    --color-tooltip-bg: #111111;
+    --color-tooltip-text: #fefefe;
   }
 
   #ghlink:not([data-theme]) {
@@ -17,11 +21,15 @@
 :root[data-theme="light"] {
   --color-bg: #fefefe;
   --color-text: #111111;
+  --color-tooltip-bg: #fefefe;
+  --color-tooltip-text: #111111;
 }
 
 :root[data-theme="dark"] {
   --color-bg: #111111;
   --color-text: #fefefe;
+  --color-tooltip-bg: #111111;
+  --color-tooltip-text: #fefefe;
 }
 
 :root[data-theme="light"] #ghlink {
@@ -73,6 +81,8 @@ body {
   width: 120px;
   left: 0;
   visibility: hidden;
+  background-color: var(--color-tooltip-bg);
+  color: var(--color-tooltip-text);
   text-align: center;
   border-radius: 6px;
   padding: 5px 5px;

--- a/src/menu/popup.html
+++ b/src/menu/popup.html
@@ -13,7 +13,7 @@
   <body>
     <center>
       <img
-        id="ghlink"
+        id="logo"
         src="../../icons/hideshort-64.png"
         title="Hide Youtube-Shorts"
       />

--- a/src/menu/popup.html
+++ b/src/menu/popup.html
@@ -1,175 +1,224 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-    <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=M+PLUS+2&display=swap" rel="stylesheet">
-        <meta charset="utf-8">
-        <link href="popup.css" rel="stylesheet">
-    </head>
-    <body>
-        <center>
-            <img id="ghlink" src="../../icons/hideshort-64.png" title="Hide Youtube-Shorts">
-            <h2>Hide Youtube-Shorts</h2>
-        </center>
+  <head>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=M+PLUS+2&display=swap"
+      rel="stylesheet"
+    />
+    <meta charset="utf-8" />
+    <link href="popup.css" rel="stylesheet" />
+  </head>
+  <body>
+    <center>
+      <img
+        id="ghlink"
+        src="../../icons/hideshort-64.png"
+        title="Hide Youtube-Shorts"
+      />
+      <h2>Hide Youtube-Shorts</h2>
+    </center>
 
-        <!-- Options -->
-        <fieldset id="settings" style="pointer-events: auto; opacity: 1;">
-            <legend id="settings_text">
-                Options
-            </legend>
+    <!-- Options -->
+    <fieldset id="settings" style="pointer-events: auto; opacity: 1">
+      <legend id="settings_text">Options</legend>
 
+      <label class="setting">
+        <input type="checkbox" id="hideYTShortsVideosInput" />
+        <span id="hide_videos_text" class="switchLabel" title="">
+          Hide shorts videos
+        </span>
+      </label>
+      <br />
+      <label class="setting">
+        <input type="checkbox" id="hideYTShortsTabInput" />
+        <span id="hide_tab_text" class="switchLabel"> Hide shorts tab </span>
+      </label>
+      <br />
+      <label class="setting">
+        <input type="checkbox" id="hideYTShortsNotificationsInput" />
+        <span id="hide_notifications_text" class="switchLabel">
+          Hide shorts in notifications
+        </span>
+      </label>
+    </fieldset>
+
+    <details>
+      <summary>
+        <span id="more_dropdown_text" class="summary-title">More</span>
+      </summary>
+      <div class="more-dropdown">
+        <div class="summary-content">
+          <fieldset id="settings_more" style="pointer-events: auto; opacity: 1">
+            <legend id="settings_hiding_on_text">Hiding on</legend>
             <label class="setting">
-                <input type="checkbox" id="hideYTShortsVideosInput">
-                <span id="hide_videos_text" class="switchLabel" title="">
-                    Hide shorts videos
-                </span>
+              <input type="checkbox" id="hideYTShortsVideosOnHomePageInput" />
+              <span id="hide_videos_home_text" class="switchLabel">
+                Home page
+              </span>
             </label>
-            <br>
+            <br />
             <label class="setting">
-                <input type="checkbox" id="hideYTShortsTabInput">
-                <span id="hide_tab_text" class="switchLabel">
-                    Hide shorts tab
-                </span>
+              <input
+                type="checkbox"
+                id="hideYTShortsVideosOnSubscriptionPageInput"
+              />
+              <span id="hide_videos_subscription_text" class="switchLabel">
+                Subscription page
+              </span>
             </label>
-            <br>
+            <br />
             <label class="setting">
-                <input type="checkbox" id="hideYTShortsNotificationsInput">
-                <span id="hide_notifications_text" class="switchLabel">
-                    Hide shorts in notifications
-                </span>
+              <input type="checkbox" id="hideYTShortsVideosOnSearchPageInput" />
+              <span id="hide_videos_search_text" class="switchLabel">
+                Search page
+              </span>
             </label>
-        </fieldset>
-
-        <details>
-            <summary>
-                <span id="more_dropdown_text" class="summary-title">More</span>
-            </summary>
-            <div class="more-dropdown">
-                <div class="summary-content">
-                    <fieldset id="settings_more" style="pointer-events: auto; opacity: 1;">
-                        <legend id="settings_hiding_on_text">
-                            Hiding on
-                        </legend>
-                        <label class="setting">
-                            <input type="checkbox" id="hideYTShortsVideosOnHomePageInput">
-                            <span id="hide_videos_home_text" class="switchLabel">
-                                Home page
-                            </span>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="hideYTShortsVideosOnSubscriptionPageInput">
-                            <span id="hide_videos_subscription_text" class="switchLabel">
-                                Subscription page
-                            </span>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="hideYTShortsVideosOnSearchPageInput">
-                            <span id="hide_videos_search_text" class="switchLabel">
-                                Search page
-                            </span>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="hideYTShortsVideosOnChannelPageInput">
-                            <span id="hide_videos_channel_text" class="switchLabel">
-                                Channel page
-                            </span>
-                        </label>
-                    </fieldset>
-                </div>
-
-                <div class="summary-content">
-                    <fieldset id="settings_more" style="pointer-events: auto; opacity: 1;">
-                        <legend id="settings_performance_text">
-                            Performance
-                        </legend>
-
-                        <label class="setting">
-                            <label class="tooltip">
-                                <input type="checkbox" id="hidingShortsTimeoutTimeMsInputCheckbox">
-                                <span id="hide_shorts_timeout_tooltip_text" class="tooltiptext">Dont allow checking for shorts more often than specified time. Bigger timeout then  better performance but shorts might not get hidden immediatelly</span>
-                                <span id="hide_shorts_timeout_text" class="switchLabel">
-                                    Timeout for rechecking videos (ms)
-                                </span>
-                                <input type="number" id="hidingShortsTimeoutTimeMsInput" min="0" max="10000" style="width: 50px">
-                            </label>
-                        </label>
-                    </fieldset>
-                </div>
-
-                <div class="summary-content">
-                    <fieldset id="settings_more" style="pointer-events: auto; opacity: 1;">
-                        <legend id="settings_experimental_text">
-                            Experimental
-                        </legend>
-
-                        <label class="setting">
-                            <label class="tooltip">
-                                <input type="checkbox" id="subscriptionShelfCloseButtonInputCheckbox">
-                                <span id="subscription_shelf_close_button_tooltip_text" class="tooltiptext">Adds a close button to the shelf with shorts on subscription page</span>
-                                <span id="subscription_shelf_close_button_text" class="switchLabel">
-                                    Shelf close button
-                                </span>
-                            </label>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <label class="tooltip">
-                                <input type="checkbox" id="hidingShortVideosTimeSecondsInputCheckbox">
-                                <span id="hide_short_videos_tooltip_text" class="tooltiptext">Hides videos that are shorter than specified time in seconds</span>
-                                <span id="hide_short_videos_text" class="switchLabel">
-                                    Hide videos shorter than (s)
-                                </span>
-                                <input type="number" id="hidingShortVideosTimeSecondsInput" min="0" max="1000" style="width: 50px">
-                            </label>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="hidingLiveVideosInputCheckbox">
-                            <span id="hide_live_videos_text" class="switchLabel">
-                                Hide Live videos
-                            </span>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="hidingUpcomingVideosInputCheckbox">
-                            <span id="hide_upcoming_videos_text" class="switchLabel">
-                                Hide Upcoming videos
-                            </span>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="shortsInOriginalVideoPlayerInputCheckbox">
-                            <span id="shorts_in_original_video_player_text" class="switchLabel">
-                                Redirect original video player
-                            </span>
-                        </label>
-                        <br>
-                        <label class="setting">
-                            <input type="checkbox" id="hidingPostsCheckbox">
-                            <span id="hide_posts_text" class="switchLabel">
-	                            Hide posts
-                            </span>
-                        </label>
-                    </fieldset>
-                </div>
-            </div>
-        </details>
-
-        <div class="bottom">
-            <!-- Links -->
-            <a href="https://github.com/Vulpelo/hide-youtube-shorts">
-                <img id="ghlink" src="../../icons/GitHub-Mark-32px.png" title="GitHub" width="20" height="20">
-            </a>
-            <!-- Version -->
-            <a class="right">
-                <span style="text-align: right;" id="ext-version"></span>
-            </a>
+            <br />
+            <label class="setting">
+              <input
+                type="checkbox"
+                id="hideYTShortsVideosOnChannelPageInput"
+              />
+              <span id="hide_videos_channel_text" class="switchLabel">
+                Channel page
+              </span>
+            </label>
+          </fieldset>
         </div>
-        <script src="permissions.js"></script>
-        <script src="popup.js"></script>
-    </body>
+
+        <div class="summary-content">
+          <fieldset id="settings_more" style="pointer-events: auto; opacity: 1">
+            <legend id="settings_performance_text">Performance</legend>
+
+            <label class="setting">
+              <label class="tooltip">
+                <input
+                  type="checkbox"
+                  id="hidingShortsTimeoutTimeMsInputCheckbox"
+                />
+                <span id="hide_shorts_timeout_tooltip_text" class="tooltiptext"
+                  >Dont allow checking for shorts more often than specified
+                  time. Bigger timeout then better performance but shorts might
+                  not get hidden immediatelly</span
+                >
+                <span id="hide_shorts_timeout_text" class="switchLabel">
+                  Timeout for rechecking videos (ms)
+                </span>
+                <input
+                  type="number"
+                  id="hidingShortsTimeoutTimeMsInput"
+                  min="0"
+                  max="10000"
+                  style="width: 50px"
+                />
+              </label>
+            </label>
+          </fieldset>
+        </div>
+
+        <div class="summary-content">
+          <fieldset id="settings_more" style="pointer-events: auto; opacity: 1">
+            <legend id="settings_experimental_text">Experimental</legend>
+
+            <label class="setting">
+              <label class="tooltip">
+                <input
+                  type="checkbox"
+                  id="subscriptionShelfCloseButtonInputCheckbox"
+                />
+                <span
+                  id="subscription_shelf_close_button_tooltip_text"
+                  class="tooltiptext"
+                  >Adds a close button to the shelf with shorts on subscription
+                  page</span
+                >
+                <span
+                  id="subscription_shelf_close_button_text"
+                  class="switchLabel"
+                >
+                  Shelf close button
+                </span>
+              </label>
+            </label>
+            <br />
+            <label class="setting">
+              <label class="tooltip">
+                <input
+                  type="checkbox"
+                  id="hidingShortVideosTimeSecondsInputCheckbox"
+                />
+                <span id="hide_short_videos_tooltip_text" class="tooltiptext"
+                  >Hides videos that are shorter than specified time in
+                  seconds</span
+                >
+                <span id="hide_short_videos_text" class="switchLabel">
+                  Hide videos shorter than (s)
+                </span>
+                <input
+                  type="number"
+                  id="hidingShortVideosTimeSecondsInput"
+                  min="0"
+                  max="1000"
+                  style="width: 50px"
+                />
+              </label>
+            </label>
+            <br />
+            <label class="setting">
+              <input type="checkbox" id="hidingLiveVideosInputCheckbox" />
+              <span id="hide_live_videos_text" class="switchLabel">
+                Hide Live videos
+              </span>
+            </label>
+            <br />
+            <label class="setting">
+              <input type="checkbox" id="hidingUpcomingVideosInputCheckbox" />
+              <span id="hide_upcoming_videos_text" class="switchLabel">
+                Hide Upcoming videos
+              </span>
+            </label>
+            <br />
+            <label class="setting">
+              <input
+                type="checkbox"
+                id="shortsInOriginalVideoPlayerInputCheckbox"
+              />
+              <span
+                id="shorts_in_original_video_player_text"
+                class="switchLabel"
+              >
+                Redirect original video player
+              </span>
+            </label>
+            <br />
+            <label class="setting">
+              <input type="checkbox" id="hidingPostsCheckbox" />
+              <span id="hide_posts_text" class="switchLabel"> Hide posts </span>
+            </label>
+          </fieldset>
+        </div>
+      </div>
+    </details>
+
+    <div class="bottom">
+      <!-- Links -->
+      <a href="https://github.com/Vulpelo/hide-youtube-shorts">
+        <img
+          id="ghlink"
+          src="../../icons/GitHub-Mark-32px.png"
+          title="GitHub"
+          width="20"
+          height="20"
+        />
+      </a>
+      <!-- Version -->
+      <a class="right">
+        <span style="text-align: right" id="ext-version"></span>
+      </a>
+    </div>
+    <script src="permissions.js"></script>
+    <script src="popup.js"></script>
+  </body>
 </html>

--- a/src/menu/popup.html
+++ b/src/menu/popup.html
@@ -9,8 +9,33 @@
     />
     <meta charset="utf-8" />
     <link href="popup.css" rel="stylesheet" />
+    <link href="popup-color-scheme.css" rel="stylesheet" />
   </head>
   <body>
+    <div id="theme-toggle">
+      <button id="theme-button">
+        <span class="sun">
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+            <circle cx="12" cy="12" r="5" fill="black" />
+            <g stroke="black" stroke-width="2" stroke-linecap="round">
+              <line x1="12" y1="1" x2="12" y2="4" />
+              <line x1="12" y1="20" x2="12" y2="23" />
+              <line x1="4.22" y1="4.22" x2="6.34" y2="6.34" />
+              <line x1="17.66" y1="17.66" x2="19.78" y2="19.78" />
+              <line x1="1" y1="12" x2="4" y2="12" />
+              <line x1="20" y1="12" x2="23" y2="12" />
+              <line x1="4.22" y1="19.78" x2="6.34" y2="17.66" />
+              <line x1="17.66" y1="6.34" x2="19.78" y2="4.22" />
+            </g>
+          </svg>
+        </span>
+        <span class="moon">
+          <svg viewBox="0 0 24 24" width="20" height="20">
+            <path d="M21 12a9 9 0 1 1-9-9 7 7 0 0 0 9 9z" fill="white" />
+          </svg>
+        </span>
+      </button>
+    </div>
     <center>
       <img
         id="logo"
@@ -220,5 +245,6 @@
     </div>
     <script src="permissions.js"></script>
     <script src="popup.js"></script>
+    <script src="color-scheme.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Why

A small UX gain, when I tried the theme out the bright white caught me off guard so I figured adding a default based on your browser settings would be a nice to have.

## Features

1. Defaults with your `@media prefers-color-scheme` variable.
2. Adds a button with a Moon and Sun SVG alongside basic JS (using `localStorage` and the `data-theme` attribute) to toggle between the color schemes.

## Notable changes

Do note that in 37511ba15c9e18c66bb7f0277335747177f061f7 I also change the ID attribute for the logo from `ghicon` to `logo` in order to have uniqueness as defined by the HTML standards and to also ensure I can change the GitHub Icon dynamically with the `filter: invert(100%);` CSS.

Formatting in f9d18ee6cbcffebb4f77a50c29447dc3db0711a2 and 948bfcc8c99559e0fc3b30128f55aaadb265d4bb  was done with prettier. Feel free to review code at 37511ba15c9e18c66bb7f0277335747177f061f7...948bfcc8c99559e0fc3b30128f55aaadb265d4bb separately from 948bfcc8c99559e0fc3b30128f55aaadb265d4bb...8bb8625319f68b58804c7d97333b3cf40714f593.

## End Result

### Google Chrome

<img width="175" height="420" alt="Base Dark" src="https://github.com/user-attachments/assets/12794718-c03b-43f7-a24d-2324b384fa31" />

<img width="183" height="423" alt="Tooltip Dark" src="https://github.com/user-attachments/assets/7e215db3-294b-4052-8572-d01e28ba3913" />

<br />

<img width="174" height="419" alt="Base Light" src="https://github.com/user-attachments/assets/8a8e8435-9262-47d4-9a83-7db11f17fb9f" />

<img width="172" height="420" alt="Tooltip Light" src="https://github.com/user-attachments/assets/3aa02d93-fed7-4a4f-9363-07a83e78eeed" />


### Firefox

<img width="261" height="650" alt="Base Dark" src="https://github.com/user-attachments/assets/593fc391-884b-4509-a22d-c1677eaad984" />

<img width="264" height="645" alt="Tooltip Dark" src="https://github.com/user-attachments/assets/0fb2c298-7f84-4698-9ee4-b569887f10b4" />

<br />

<img width="254" height="643" alt="Base Light" src="https://github.com/user-attachments/assets/7f3bab03-f2f4-4b4f-955c-06603575eac7" />

<img width="255" height="643" alt="Tooltip Light" src="https://github.com/user-attachments/assets/db269b6e-4a7c-4772-92a2-2fc4874c4858" />